### PR TITLE
More unit tests, fixes for some failing unit tests

### DIFF
--- a/nodes/errors.js
+++ b/nodes/errors.js
@@ -73,7 +73,6 @@ function validateQubitInput(msg) {
 
 function validateRegisterInput(msg) {
   let keys = Object.keys(msg.payload);
-
   if (msg.topic !== 'Quantum Circuit') {
     return new Error(NOT_QUANTUM_NODE);
   } else if (keys.includes('register') && typeof msg.payload.register === 'undefined') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "node-red-contrib-quantum",
       "version": "0.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/test/nodes/barrier_spec.js
+++ b/test/nodes/barrier_spec.js
@@ -23,7 +23,7 @@ describe('BarrierNode', function() {
     testUtil.isLoaded(barrierNode, 'barrier', done);
   });
 
-  xit('pass qubit through node', function(done) {
+  it('pass qubit through node', function(done) {
     flow.add('quantum-circuit', 'n0', [['n1'], ['n2'], ['n3']],
         {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '3'});
     flow.add('hadamard-gate', 'n1', [['n3']]);
@@ -31,7 +31,7 @@ describe('BarrierNode', function() {
     flow.add('barrier', 'n3', [['n4'], ['n4'], ['n4']], {outputs: '3'});
     flow.addOutput('n4');
 
-    let payloadObject = [{
+    let payloadObjectList = [{
       structure: {qubits: 3, cbits: 3},
       register: undefined,
       qubit: 0,
@@ -45,7 +45,7 @@ describe('BarrierNode', function() {
       qubit: 2,
     }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/barrier_spec.js
+++ b/test/nodes/barrier_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const barrierNode = require('../../nodes/quantum/barrier/barrier.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -55,4 +56,24 @@ describe('BarrierNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('barrier', 'n1', [['n2']], {outputs: '1'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('barrier', 'n1', [['n2']], {outputs: '1'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+
 });

--- a/test/nodes/barrier_spec.js
+++ b/test/nodes/barrier_spec.js
@@ -74,6 +74,4 @@ describe('BarrierNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
-
 });

--- a/test/nodes/barrier_spec.js
+++ b/test/nodes/barrier_spec.js
@@ -63,7 +63,7 @@ describe('BarrierNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -72,6 +72,6 @@ describe('BarrierNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/bloch-sphere_spec.js
+++ b/test/nodes/bloch-sphere_spec.js
@@ -41,7 +41,7 @@ describe('BlochSphereNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -50,6 +50,6 @@ describe('BlochSphereNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/bloch-sphere_spec.js
+++ b/test/nodes/bloch-sphere_spec.js
@@ -22,7 +22,7 @@ describe('BlochSphereNode', function() {
     testUtil.isLoaded(blochSphereNode, 'bloch-sphere', done);
   });
 
-  xit('execute command', function(done) {
+  it('execute command', function(done) {
     let command = snippets.BLOCH_SPHERE + snippets.ENCODE_IMAGE;
     flow.add('quantum-circuit', 'n0', [['n1'], ['n2'], ['n3']],
         {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '1'});

--- a/test/nodes/bloch-sphere_spec.js
+++ b/test/nodes/bloch-sphere_spec.js
@@ -3,6 +3,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const blochSphereNode = require('../../nodes/quantum/bloch-sphere/bloch-sphere.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -21,7 +22,7 @@ describe('BlochSphereNode', function() {
     testUtil.isLoaded(blochSphereNode, 'bloch-sphere', done);
   });
 
-  it('execute command', function(done) {
+  xit('execute command', function(done) {
     let command = snippets.BLOCH_SPHERE + snippets.ENCODE_IMAGE;
     flow.add('quantum-circuit', 'n0', [['n1'], ['n2'], ['n3']],
         {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '1'});
@@ -31,7 +32,24 @@ describe('BlochSphereNode', function() {
     flow.add('toffoli-gate', 'n4', [['n5'], ['n5'], ['n5']], {targetPosition: 'Middle'});
     flow.add('bloch-sphere', 'n5', [['n6']]);
     flow.addOutput('n6');
-
     testUtil.commandExecuted(flow, command, done);
+  });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('bloch-sphere', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('bloch-sphere', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/circuit-diagram_spec.js
+++ b/test/nodes/circuit-diagram_spec.js
@@ -39,7 +39,7 @@ describe('CircuitDiagramNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -48,6 +48,6 @@ describe('CircuitDiagramNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/circuit-diagram_spec.js
+++ b/test/nodes/circuit-diagram_spec.js
@@ -3,6 +3,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const circuitDiagramNode = require('../../nodes/quantum/circuit-diagram/circuit-diagram.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -30,5 +31,23 @@ describe('CircuitDiagramNode', function() {
     flow.addOutput('n4');
 
     testUtil.commandExecuted(flow, command, done);
+  });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('circuit-diagram', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('circuit-diagram', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/classical-register_spec.js
+++ b/test/nodes/classical-register_spec.js
@@ -4,6 +4,7 @@ const classicalRegisterNode = require('../../nodes/quantum/classical-register/cl
 const {FlowBuilder} = require('../flow-builder');
 const nodeTestHelper = testUtil.nodeTestHelper;
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -31,5 +32,21 @@ describe('ClassicalRegisterNode', function() {
     flow.addOutput('n3');
 
     testUtil.commandExecuted(flow, command, done);
+  });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('classical-register', 'n1', [[]], {classicalBits: '3', name: 'test'});
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('classical-register', 'n1', [[]], {classicalBits: '3', name: 'test'});
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_REGISTER_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/classical-register_spec.js
+++ b/test/nodes/classical-register_spec.js
@@ -39,7 +39,7 @@ describe('ClassicalRegisterNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-register object', function(done) {
@@ -47,6 +47,6 @@ describe('ClassicalRegisterNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_REGISTER_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/classical-register_spec.js
+++ b/test/nodes/classical-register_spec.js
@@ -42,7 +42,7 @@ describe('ClassicalRegisterNode', function() {
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 
-  it('should fail on receiving non-qubit object', function(done) {
+  it('should fail on receiving non-register object', function(done) {
     flow.add('classical-register', 'n1', [[]], {classicalBits: '3', name: 'test'});
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};

--- a/test/nodes/cnot-gate_spec.js
+++ b/test/nodes/cnot-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const cnotGateNode = require('../../nodes/quantum/cnot-gate/cnot-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -49,5 +50,23 @@ describe('CnotGateNode', function() {
     flow.addOutput('n2');
 
     testUtil.commandExecuted(flow, command, done);
+  });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('cnot-gate', 'n1', [['n2']], {targetPosition: 'Upper'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('cnot-gate', 'n1', [['n2']], {targetPosition: 'Upper'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/cnot-gate_spec.js
+++ b/test/nodes/cnot-gate_spec.js
@@ -23,13 +23,13 @@ describe('CnotGateNode', function() {
     testUtil.isLoaded(cnotGateNode, 'cnot-gate', done);
   });
 
-  xit('pass qubit through gate', function(done) {
+  it('pass qubit through gate', function(done) {
     flow.add('quantum-circuit', 'n0', [['n1'], ['n1']],
         {structure: 'qubits', outputs: '2', qbitsreg: '2', cbitsreg: '2'});
     flow.add('cnot-gate', 'n1', [['n2'], ['n2']], {targetPosition: 'Upper'});
     flow.addOutput('n2');
 
-    let payloadObject = [
+    let payloadObjectList = [
       {structure: {qubits: 2, cbits: 2},
         register: undefined,
         qubit: 0},
@@ -38,7 +38,7 @@ describe('CnotGateNode', function() {
         qubit: 1},
     ];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/cnot-gate_spec.js
+++ b/test/nodes/cnot-gate_spec.js
@@ -58,7 +58,7 @@ describe('CnotGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -67,6 +67,6 @@ describe('CnotGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/controlled-u-gate_spec.js
+++ b/test/nodes/controlled-u-gate_spec.js
@@ -26,7 +26,7 @@ describe('ControlledUGateNode', function() {
   it('pass qubit through gate', function(done) {
     flow.add('quantum-circuit', 'n0', [['n1'], ['n1']],
         {structure: 'qubits', outputs: '2', qbitsreg: '2', cbitsreg: '2'});
-    flow.add('controlled-u-gate', 'n1', [['n2'],['n2']],
+    flow.add('controlled-u-gate', 'n1', [['n2'], ['n2']],
         {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
     flow.addOutput('n2');
 
@@ -34,7 +34,7 @@ describe('ControlledUGateNode', function() {
       structure: {qubits: 2, cbits: 2},
       register: undefined,
       qubit: 0,
-    },{
+    }, {
       structure: {qubits: 2, cbits: 2},
       register: undefined,
       qubit: 1,
@@ -56,7 +56,7 @@ describe('ControlledUGateNode', function() {
 
   it('should fail on receiving input from non-quantum nodes', function(done) {
     flow.add('controlled-u-gate', 'n1', [['n2']],
-      {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
+        {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
     flow.addOutput('n2');
 
     const givenInput = {payload: '', topic: ''};
@@ -66,7 +66,7 @@ describe('ControlledUGateNode', function() {
 
   it('should fail on receiving non-qubit object', function(done) {
     flow.add('controlled-u-gate', 'n1', [['n2']],
-      {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
+        {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
     flow.addOutput('n2');
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};

--- a/test/nodes/controlled-u-gate_spec.js
+++ b/test/nodes/controlled-u-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const controlledUGateNode = require('../../nodes/quantum/controlled-u-gate/controlled-u-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -47,5 +48,25 @@ describe('ControlledUGateNode', function() {
     flow.addOutput('n2');
 
     testUtil.commandExecuted(flow, command, done);
+  });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('controlled-u-gate', 'n1', [['n2']],
+      {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('controlled-u-gate', 'n1', [['n2']],
+      {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/controlled-u-gate_spec.js
+++ b/test/nodes/controlled-u-gate_spec.js
@@ -61,7 +61,7 @@ describe('ControlledUGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -71,6 +71,6 @@ describe('ControlledUGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/controlled-u-gate_spec.js
+++ b/test/nodes/controlled-u-gate_spec.js
@@ -23,20 +23,24 @@ describe('ControlledUGateNode', function() {
     testUtil.isLoaded(controlledUGateNode, 'controlled-u-gate', done);
   });
 
-  xit('pass qubit through gate', function(done) {
+  it('pass qubit through gate', function(done) {
     flow.add('quantum-circuit', 'n0', [['n1'], ['n1']],
         {structure: 'qubits', outputs: '2', qbitsreg: '2', cbitsreg: '2'});
-    flow.add('controlled-u-gate', 'n1', [['n2']],
+    flow.add('controlled-u-gate', 'n1', [['n2'],['n2']],
         {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
     flow.addOutput('n2');
 
-    let payloadObject = {
-      structure: {qubits: 1, cbits: 1},
+    let payloadObjectList = [{
+      structure: {qubits: 2, cbits: 2},
       register: undefined,
       qubit: 0,
-    };
+    },{
+      structure: {qubits: 2, cbits: 2},
+      register: undefined,
+      qubit: 1,
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/grovers_spec.js
+++ b/test/nodes/grovers_spec.js
@@ -42,16 +42,10 @@ describe('GroversNode', function() {
 
   it('should fail on invalid input', function(done) {
     flow = new FlowBuilder();
-    flow.add('grovers', 'groversNode', []);
+    flow.add('grovers', 'n1', []);
 
-    nodeTestHelper.load(flow.nodes, flow.flow, function() {
-      let groversTestNode = nodeTestHelper.getNode('groversNode');
-      groversTestNode.on('call:error', (call)=> {
-        const actualError = call.firstArg;
-        assert.strictEqual(actualError.message, errors.NOT_BIT_STRING);
-        done();
-      });
-      groversTestNode.receive({payload: '111112'});
-    });
+    const givenInput = {payload: "11112"};
+    const expectedMessage = errors.NOT_BIT_STRING;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/grovers_spec.js
+++ b/test/nodes/grovers_spec.js
@@ -44,7 +44,7 @@ describe('GroversNode', function() {
     flow = new FlowBuilder();
     flow.add('grovers', 'n1', []);
 
-    const givenInput = {payload: "11112"};
+    const givenInput = {payload: '11112'};
     const expectedMessage = errors.NOT_BIT_STRING;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });

--- a/test/nodes/grovers_spec.js
+++ b/test/nodes/grovers_spec.js
@@ -46,6 +46,6 @@ describe('GroversNode', function() {
 
     const givenInput = {payload: '11112'};
     const expectedMessage = errors.NOT_BIT_STRING;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/hadamard-gate_spec.js
+++ b/test/nodes/hadamard-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const hadamardGateNode = require('../../nodes/quantum/hadamard-gate/hadamard-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -43,5 +44,23 @@ describe('HadamardGateNode', function() {
     flow.addOutput('n2');
 
     testUtil.commandExecuted(flow, command, done);
+  });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('hadamard-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('hadamard-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/hadamard-gate_spec.js
+++ b/test/nodes/hadamard-gate_spec.js
@@ -52,7 +52,7 @@ describe('HadamardGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -61,6 +61,6 @@ describe('HadamardGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/hadamard-gate_spec.js
+++ b/test/nodes/hadamard-gate_spec.js
@@ -28,13 +28,13 @@ describe('HadamardGateNode', function() {
     flow.add('hadamard-gate', 'n1', [['n2']]);
     flow.addOutput('n2');
 
-    let payloadObject = {
+    let payloadObjectList = [{
       structure: {qubits: 1, cbits: 1},
       register: undefined,
       qubit: 0,
-    };
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/ibm-quantum-system_spec.js
+++ b/test/nodes/ibm-quantum-system_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const ibmQuantumSystemNode = require('../../nodes/quantum/ibm-quantum-system/ibm-quantum-system.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -37,4 +38,24 @@ describe('IBMQuantumSystemNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   }).timeout(180000); // Needs long timeout as it takes awhile for IBM server to respond
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('ibm-quantum-system', 'n1', [['n2']], {api_token: API_TOKEN,
+      preferred_backend: '', preferred_output: ' Results'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('ibm-quantum-system', 'n1', [['n2']], {api_token: API_TOKEN,
+      preferred_backend: '', preferred_output: ' Results'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
 });

--- a/test/nodes/ibm-quantum-system_spec.js
+++ b/test/nodes/ibm-quantum-system_spec.js
@@ -46,7 +46,7 @@ describe('IBMQuantumSystemNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -56,6 +56,6 @@ describe('IBMQuantumSystemNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/identity-gate_spec.js
+++ b/test/nodes/identity-gate_spec.js
@@ -52,7 +52,7 @@ describe('IdentityGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -61,6 +61,6 @@ describe('IdentityGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/identity-gate_spec.js
+++ b/test/nodes/identity-gate_spec.js
@@ -63,5 +63,4 @@ describe('IdentityGateNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/identity-gate_spec.js
+++ b/test/nodes/identity-gate_spec.js
@@ -28,13 +28,13 @@ describe('IdentityGateNode', function() {
     flow.add('identity-gate', 'n1', [['n2']]);
     flow.addOutput('n2');
 
-    let payloadObject = {
+    let payloadObjectList = [{
       structure: {qubits: 1, cbits: 1},
       register: undefined,
       qubit: 0,
-    };
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/identity-gate_spec.js
+++ b/test/nodes/identity-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const identityGateNode = require('../../nodes/quantum/identity-gate/identity-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -44,4 +45,23 @@ describe('IdentityGateNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('identity-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('identity-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -40,7 +40,7 @@ describe('LocalSimulatorNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -49,7 +49,7 @@ describe('LocalSimulatorNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should return correct output for qubit only circuit', function(done) {

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -66,9 +66,9 @@ describe('LocalSimulatorNode', function() {
 
   xit('should return correct output for register only circuit', function(done) {
     flow.add('quantum-circuit', 'qc', [['qr'], ['cr']],
-      {structure: 'registers', outputs: '2', qbitsreg: '1', cbitsreg: '1'});
-    flow.add('classical-register', 'cr', [[]], {classicalBits:'2'});
-    flow.add('quantum-register', 'qr', [['ng', 'm1']], {outputs:2});
+        {structure: 'registers', outputs: '2', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('classical-register', 'cr', [[]], {classicalBits: '2'});
+    flow.add('quantum-register', 'qr', [['ng', 'm1']], {outputs: 2});
     flow.add('not-gate', 'ng', [['m2']]);
     flow.add('measure', 'm1', [['si']], {selectedBit: 0});
     flow.add('measure', 'm2', [['si']], {selectedBit: 1});

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const localSimulatorNode = require('../../nodes/quantum/local-simulator/local-simulator.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -32,4 +33,23 @@ describe('LocalSimulatorNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('local-simulator', 'n1', [['n2']], {shots: '1'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('local-simulator', 'n1', [['n2']], {shots: '1'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -19,11 +19,11 @@ describe('LocalSimulatorNode', function() {
     nodeTestHelper.stopServer(done);
   });
 
-  it('load node', function(done) {
+  xit('load node', function(done) {
     testUtil.isLoaded(localSimulatorNode, 'local-simulator', done);
   });
 
-  it('execute command', function(done) {
+  xit('execute command', function(done) {
     let command = util.format(snippets.LOCAL_SIMULATOR, '1');
     flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
     flow.add('hadamard-gate', 'n1', [['n2']]);
@@ -34,7 +34,7 @@ describe('LocalSimulatorNode', function() {
     testUtil.commandExecuted(flow, command, done);
   });
 
-  it('should fail on receiving input from non-quantum nodes', function(done) {
+  xit('should fail on receiving input from non-quantum nodes', function(done) {
     flow.add('local-simulator', 'n1', [['n2']], {shots: '1'});
     flow.addOutput('n2');
 
@@ -43,12 +43,40 @@ describe('LocalSimulatorNode', function() {
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 
-  it('should fail on receiving non-qubit object', function(done) {
+  xit('should fail on receiving non-qubit object', function(done) {
     flow.add('local-simulator', 'n1', [['n2']], {shots: '1'});
     flow.addOutput('n2');
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  xit('should return correct output for qubit only circuit', function(done) {
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('not-gate', 'n1', [['n2']]);
+    flow.add('measure', 'n2', [['n3']], {selectedBit: '0'});
+    flow.add('local-simulator', 'n3', [['n4']], {shots: '1'});
+    flow.addOutput('n4');
+
+    const givenInput = {payload: ''};
+    const expectedOutput = {'1': 1};
+    testUtil.correctOutputReceived(flow, givenInput, expectedOutput, done);
+  });
+
+  xit('should return correct output for register only circuit', function(done) {
+    flow.add('quantum-circuit', 'qc', [['qr'], ['cr']],
+      {structure: 'registers', outputs: '2', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('classical-register', 'cr', [[]], {classicalBits:'2'});
+    flow.add('quantum-register', 'qr', [['ng', 'm1']], {outputs:2});
+    flow.add('not-gate', 'ng', [['m2']]);
+    flow.add('measure', 'm1', [['si']], {selectedBit: 0});
+    flow.add('measure', 'm2', [['si']], {selectedBit: 1});
+    flow.add('local-simulator', 'si', [['out']], {shots: '1'});
+    flow.addOutput('out');
+
+    const givenInput = {payload: ''};
+    const expectedOutput = {'10': 1};
+    testUtil.correctOutputReceived(flow, givenInput, expectedOutput, done);
   });
 });

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -19,11 +19,11 @@ describe('LocalSimulatorNode', function() {
     nodeTestHelper.stopServer(done);
   });
 
-  xit('load node', function(done) {
+  it('load node', function(done) {
     testUtil.isLoaded(localSimulatorNode, 'local-simulator', done);
   });
 
-  xit('execute command', function(done) {
+  it('execute command', function(done) {
     let command = util.format(snippets.LOCAL_SIMULATOR, '1');
     flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
     flow.add('hadamard-gate', 'n1', [['n2']]);
@@ -34,7 +34,7 @@ describe('LocalSimulatorNode', function() {
     testUtil.commandExecuted(flow, command, done);
   });
 
-  xit('should fail on receiving input from non-quantum nodes', function(done) {
+  it('should fail on receiving input from non-quantum nodes', function(done) {
     flow.add('local-simulator', 'n1', [['n2']], {shots: '1'});
     flow.addOutput('n2');
 
@@ -43,7 +43,7 @@ describe('LocalSimulatorNode', function() {
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 
-  xit('should fail on receiving non-qubit object', function(done) {
+  it('should fail on receiving non-qubit object', function(done) {
     flow.add('local-simulator', 'n1', [['n2']], {shots: '1'});
     flow.addOutput('n2');
 
@@ -52,7 +52,7 @@ describe('LocalSimulatorNode', function() {
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 
-  xit('should return correct output for qubit only circuit', function(done) {
+  it('should return correct output for qubit only circuit', function(done) {
     flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
     flow.add('not-gate', 'n1', [['n2']]);
     flow.add('measure', 'n2', [['n3']], {selectedBit: '0'});

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -51,5 +51,4 @@ describe('LocalSimulatorNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/measure_spec.js
+++ b/test/nodes/measure_spec.js
@@ -55,7 +55,7 @@ describe('MeasureNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -64,6 +64,6 @@ describe('MeasureNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/measure_spec.js
+++ b/test/nodes/measure_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const measureNode = require('../../nodes/quantum/measure/measure.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -47,4 +48,23 @@ describe('MeasureNode', function() {
 
     testUtil.correctOutputReceived(flow, givenInput, expectedOutput, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('measure', 'n1', [['n2']], {selectedBit: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('measure', 'n1', [['n2']], {selectedBit: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/measure_spec.js
+++ b/test/nodes/measure_spec.js
@@ -66,5 +66,4 @@ describe('MeasureNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/multi-controlled-u-gate_spec.js
+++ b/test/nodes/multi-controlled-u-gate_spec.js
@@ -65,7 +65,7 @@ describe('MultiControlledUGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -75,6 +75,6 @@ describe('MultiControlledUGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/multi-controlled-u-gate_spec.js
+++ b/test/nodes/multi-controlled-u-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const multiControlledUGateNode = require('../../nodes/quantum/multi-controlled-u-gate/multi-controlled-u-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -56,4 +57,25 @@ describe('MultiControlledUGateNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('multi-controlled-u-gate', 'n1', [['n2'], ['n2']],
+      {outputs: '2', nbControls: '1', targetPosition: '0', theta: '0', phi: '0', lambda: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('multi-controlled-u-gate', 'n1', [['n2'], ['n2']],
+      {outputs: '2', nbControls: '1', targetPosition: '0', theta: '0', phi: '0', lambda: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/multi-controlled-u-gate_spec.js
+++ b/test/nodes/multi-controlled-u-gate_spec.js
@@ -60,7 +60,7 @@ describe('MultiControlledUGateNode', function() {
 
   it('should fail on receiving input from non-quantum nodes', function(done) {
     flow.add('multi-controlled-u-gate', 'n1', [['n2'], ['n2']],
-      {outputs: '2', nbControls: '1', targetPosition: '0', theta: '0', phi: '0', lambda: '0'});
+        {outputs: '2', nbControls: '1', targetPosition: '0', theta: '0', phi: '0', lambda: '0'});
     flow.addOutput('n2');
 
     const givenInput = {payload: '', topic: ''};
@@ -70,12 +70,11 @@ describe('MultiControlledUGateNode', function() {
 
   it('should fail on receiving non-qubit object', function(done) {
     flow.add('multi-controlled-u-gate', 'n1', [['n2'], ['n2']],
-      {outputs: '2', nbControls: '1', targetPosition: '0', theta: '0', phi: '0', lambda: '0'});
+        {outputs: '2', nbControls: '1', targetPosition: '0', theta: '0', phi: '0', lambda: '0'});
     flow.addOutput('n2');
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/not-gate_spec.js
+++ b/test/nodes/not-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const notGateNode = require('../../nodes/quantum/not-gate/not-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -44,4 +45,23 @@ describe('NotGateNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('not-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('not-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/not-gate_spec.js
+++ b/test/nodes/not-gate_spec.js
@@ -52,7 +52,7 @@ describe('NotGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -61,6 +61,6 @@ describe('NotGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/not-gate_spec.js
+++ b/test/nodes/not-gate_spec.js
@@ -63,5 +63,4 @@ describe('NotGateNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/not-gate_spec.js
+++ b/test/nodes/not-gate_spec.js
@@ -28,13 +28,13 @@ describe('NotGateNode', function() {
     flow.add('not-gate', 'n1', [['n2']]);
     flow.addOutput('n2');
 
-    let payloadObject = {
+    let payloadObjectList = [{
       structure: {qubits: 1, cbits: 1},
       register: undefined,
       qubit: 0,
-    };
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/phase-gate_spec.js
+++ b/test/nodes/phase-gate_spec.js
@@ -28,13 +28,13 @@ describe('PhaseGateNode', function() {
     flow.add('phase-gate', 'n1', [['n2']], {phase: '1'});
     flow.addOutput('n2');
 
-    let payloadObject = {
+    let payloadObjectList = [{
       structure: {qubits: 1, cbits: 1},
       register: undefined,
       qubit: 0,
-    };
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/phase-gate_spec.js
+++ b/test/nodes/phase-gate_spec.js
@@ -52,7 +52,7 @@ describe('PhaseGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -61,6 +61,6 @@ describe('PhaseGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/phase-gate_spec.js
+++ b/test/nodes/phase-gate_spec.js
@@ -63,5 +63,4 @@ describe('PhaseGateNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/phase-gate_spec.js
+++ b/test/nodes/phase-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const phaseGateNode = require('../../nodes/quantum/phase-gate/phase-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -44,4 +45,23 @@ describe('PhaseGateNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('phase-gate', 'n1', [['n2']], {phase: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('phase-gate', 'n1', [['n2']], {phase: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/quantum-register_spec.js
+++ b/test/nodes/quantum-register_spec.js
@@ -23,11 +23,11 @@ describe('QuantumRegisterNode', function() {
     testUtil.isLoaded(quantumRegisterNode, 'quantum-register', done);
   });
 
-  xit('execute command', function(done) {
+  it('execute command', function(done) {
     // Test is disabled until issue #87 is fixed
     let command = util.format(snippets.QUANTUM_REGISTER, '0', '1, "quantum_register"');
     flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'registers', outputs: '1', qbitsreg: '1', cbitsreg: '0'});
-    flow.add('quantum-register', 'n1', [['n2']]);
+    flow.add('quantum-register', 'n1', [['n2']], {outputs: 1});
     flow.addOutput('n2');
 
     testUtil.commandExecuted(flow, command, done);

--- a/test/nodes/quantum-register_spec.js
+++ b/test/nodes/quantum-register_spec.js
@@ -41,7 +41,7 @@ describe('QuantumRegisterNode', function() {
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 
-  it('should fail on receiving non-qubit object', function(done) {
+  it('should fail on receiving non-register object', function(done) {
     flow.add('quantum-register', 'n1', [[]], {outputs: 2});
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};

--- a/test/nodes/quantum-register_spec.js
+++ b/test/nodes/quantum-register_spec.js
@@ -38,7 +38,7 @@ describe('QuantumRegisterNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-register object', function(done) {
@@ -46,6 +46,6 @@ describe('QuantumRegisterNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_REGISTER_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/quantum-register_spec.js
+++ b/test/nodes/quantum-register_spec.js
@@ -4,6 +4,7 @@ const quantumRegisterNode = require('../../nodes/quantum/quantum-register/quantu
 const {FlowBuilder} = require('../flow-builder');
 const nodeTestHelper = testUtil.nodeTestHelper;
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -30,5 +31,21 @@ describe('QuantumRegisterNode', function() {
     flow.addOutput('n2');
 
     testUtil.commandExecuted(flow, command, done);
+  });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('quantum-register', 'n1', [[]], {outputs: 2});
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('quantum-register', 'n1', [[]], {outputs: 2});
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_REGISTER_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/qubit_spec.js
+++ b/test/nodes/qubit_spec.js
@@ -52,5 +52,4 @@ describe('QubitNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/qubit_spec.js
+++ b/test/nodes/qubit_spec.js
@@ -41,7 +41,7 @@ describe('QubitNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -50,6 +50,6 @@ describe('QubitNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/qubit_spec.js
+++ b/test/nodes/qubit_spec.js
@@ -2,6 +2,7 @@ const qubitNode = require('../../nodes/quantum/qubit/qubit.js');
 const testUtil = require('../test-util');
 const {FlowBuilder} = require('../flow-builder.js');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -33,4 +34,23 @@ describe('QubitNode', function() {
 
     testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('qubit', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('qubit', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/qubit_spec.js
+++ b/test/nodes/qubit_spec.js
@@ -26,13 +26,13 @@ describe('QubitNode', function() {
     flow.add('qubit', 'n1', [['n2']]);
     flow.addOutput('n2');
 
-    let payloadObject = {
+    let payloadObjectList = [{
       structure: {qubits: 1, cbits: 1},
       register: undefined,
       qubit: 0,
-    };
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('should fail on receiving input from non-quantum nodes', function(done) {

--- a/test/nodes/reset_spec.js
+++ b/test/nodes/reset_spec.js
@@ -28,13 +28,13 @@ describe('ResetNode', function() {
     flow.add('reset', 'n1', [['n2']]);
     flow.addOutput('n2');
 
-    let payloadObject = {
+    let payloadObjectList = [{
       structure: {qubits: 1, cbits: 1},
       register: undefined,
       qubit: 0,
-    };
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/reset_spec.js
+++ b/test/nodes/reset_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const resetNode = require('../../nodes/quantum/reset/reset.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -44,4 +45,23 @@ describe('ResetNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('reset', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('reset', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/reset_spec.js
+++ b/test/nodes/reset_spec.js
@@ -52,7 +52,7 @@ describe('ResetNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -61,6 +61,6 @@ describe('ResetNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/reset_spec.js
+++ b/test/nodes/reset_spec.js
@@ -63,5 +63,4 @@ describe('ResetNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/rotation-gate_spec.js
+++ b/test/nodes/rotation-gate_spec.js
@@ -63,5 +63,4 @@ describe('RotationGateNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/rotation-gate_spec.js
+++ b/test/nodes/rotation-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const rotationGateNode = require('../../nodes/quantum/rotation-gate/rotation-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -44,4 +45,23 @@ describe('RotationGateNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('rotation-gate', 'n1', [['n2']], {axis: 'x', angle: '-0.2'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('rotation-gate', 'n1', [['n2']], {axis: 'x', angle: '-0.2'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/rotation-gate_spec.js
+++ b/test/nodes/rotation-gate_spec.js
@@ -52,7 +52,7 @@ describe('RotationGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -61,6 +61,6 @@ describe('RotationGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/rotation-gate_spec.js
+++ b/test/nodes/rotation-gate_spec.js
@@ -28,13 +28,13 @@ describe('RotationGateNode', function() {
     flow.add('rotation-gate', 'n1', [['n2']], {axis: 'x', angle: '1'});
     flow.addOutput('n2');
 
-    let payloadObject = {
+    let payloadObjectList = [{
       structure: {qubits: 1, cbits: 1},
       register: undefined,
       qubit: 0,
-    };
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/script_spec.js
+++ b/test/nodes/script_spec.js
@@ -1,6 +1,7 @@
 const scriptNode = require('../../nodes/quantum/script/script.js');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
 
 
 describe('ScriptNode', function() {
@@ -15,5 +16,35 @@ describe('ScriptNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(scriptNode, 'script', done);
+  });
+
+  it('return correct script in valid circuit', function(done) {
+    flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1'], ['n2'], ['n3']],
+      {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '3'});
+    flow.add('hadamard-gate', 'n1', [['n4']]);
+    flow.add('hadamard-gate', 'n2', [['n4']]);
+    flow.add('not-gate', 'n3', [['n4']]);
+    flow.add('toffoli-gate', 'n4', [['n5'], ['n5'], ['n5']], {targetPosition: 'Middle'});
+    flow.add('script', 'n5', [['n6']]);
+    flow.addOutput('n6');
+
+    const givenInput = {payload: ''};
+    const expectedOutput = `from math import pi
+from qiskit import *
+qc = QuantumCircuit(3, 3)
+
+
+qc.h(0)
+
+
+qc.h(1)
+
+
+qc.x(2)
+
+
+qc.toffoli(0, 2, 1)`;
+    testUtil.correctOutputReceived(flow, givenInput, expectedOutput, done);
   });
 });

--- a/test/nodes/script_spec.js
+++ b/test/nodes/script_spec.js
@@ -2,6 +2,7 @@ const scriptNode = require('../../nodes/quantum/script/script.js');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
+const dedent = require('dedent-js');
 
 
 describe('ScriptNode', function() {
@@ -21,7 +22,7 @@ describe('ScriptNode', function() {
   it('return correct script in valid circuit', function(done) {
     flow = new FlowBuilder();
     flow.add('quantum-circuit', 'n0', [['n1'], ['n2'], ['n3']],
-      {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '3'});
+        {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '3'});
     flow.add('hadamard-gate', 'n1', [['n4']]);
     flow.add('hadamard-gate', 'n2', [['n4']]);
     flow.add('not-gate', 'n3', [['n4']]);
@@ -30,21 +31,22 @@ describe('ScriptNode', function() {
     flow.addOutput('n6');
 
     const givenInput = {payload: ''};
-    const expectedOutput = `from math import pi
-from qiskit import *
-qc = QuantumCircuit(3, 3)
+    const expectedOutput = dedent(
+        `from math import pi
+        from qiskit import *
+        qc = QuantumCircuit(3, 3)
 
 
-qc.h(0)
+        qc.h(0)
 
 
-qc.h(1)
+        qc.h(1)
 
 
-qc.x(2)
+        qc.x(2)
 
 
-qc.toffoli(0, 2, 1)`;
+        qc.toffoli(0, 2, 1)`);
     testUtil.correctOutputReceived(flow, givenInput, expectedOutput, done);
   });
 });

--- a/test/nodes/shors_spec.js
+++ b/test/nodes/shors_spec.js
@@ -38,7 +38,7 @@ describe('ShorsNode', function() {
 
     const givenInput = {payload: 15};
     const expectedOutput = {
-      listOfFactors: '[3, 5]'
+      listOfFactors: '[3, 5]',
     };
     testUtil.correctOutputReceived(flow, givenInput, expectedOutput, done);
   }).timeout(25000);

--- a/test/nodes/shors_spec.js
+++ b/test/nodes/shors_spec.js
@@ -48,7 +48,7 @@ describe('ShorsNode', function() {
 
     const givenInput = {payload: 1};
     const expectedMessage = errors.GREATER_THAN_TWO;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('return error for even input', function(done) {
@@ -56,7 +56,7 @@ describe('ShorsNode', function() {
 
     const givenInput = {payload: 4};
     const expectedMessage = errors.INPUT_ODD_INTEGER;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('return error for non-integer input', function(done) {
@@ -64,6 +64,6 @@ describe('ShorsNode', function() {
 
     const givenInput = {payload: 'a'};
     const expectedMessage = errors.INPUT_AN_INTEGER;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/swap_spec.js
+++ b/test/nodes/swap_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const swapNode = require('../../nodes/quantum/swap/swap.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -49,4 +50,23 @@ describe('SwapNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('swap', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('swap', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/swap_spec.js
+++ b/test/nodes/swap_spec.js
@@ -57,7 +57,7 @@ describe('SwapNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -66,6 +66,6 @@ describe('SwapNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/swap_spec.js
+++ b/test/nodes/swap_spec.js
@@ -23,13 +23,13 @@ describe('SwapNode', function() {
     testUtil.isLoaded(swapNode, 'swap', done);
   });
 
-  xit('pass qubit through node', function(done) {
+  it('pass qubit through node', function(done) {
     flow.add('quantum-circuit', 'n0', [['n1'], ['n1']],
         {structure: 'qubits', outputs: '2', qbitsreg: '2', cbitsreg: '2'});
     flow.add('swap', 'n1', [['n2'], ['n2']]);
     flow.addOutput('n2');
 
-    let payloadObject = [
+    let payloadObjectList = [
       {structure: {qubits: 2, cbits: 2},
         register: undefined,
         qubit: 0},
@@ -38,7 +38,7 @@ describe('SwapNode', function() {
         qubit: 1},
     ];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/swap_spec.js
+++ b/test/nodes/swap_spec.js
@@ -68,5 +68,4 @@ describe('SwapNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/nodes/toffoli-gate_spec.js
+++ b/test/nodes/toffoli-gate_spec.js
@@ -58,7 +58,7 @@ describe('ToffoliGateNode', function() {
   });
 
   it('should fail on receiving input from non-quantum nodes', function(done) {
-    flow.add('toffoli-gate', 'n1', [['n2'],['n2'],['n2']], {targetPosition: 'Middle'});
+    flow.add('toffoli-gate', 'n1', [['n2'], ['n2'], ['n2']], {targetPosition: 'Middle'});
     flow.addOutput('n2');
 
     const givenInput = {payload: '', topic: ''};
@@ -67,13 +67,12 @@ describe('ToffoliGateNode', function() {
   });
 
   it('should fail on receiving non-qubit object', function(done) {
-    flow.add('toffoli-gate', 'n1', [['n2'],['n2'],['n2']], {targetPosition: 'Middle'});
+    flow.add('toffoli-gate', 'n1', [['n2'], ['n2'], ['n2']], {targetPosition: 'Middle'});
     flow.addOutput('n2');
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });
 

--- a/test/nodes/toffoli-gate_spec.js
+++ b/test/nodes/toffoli-gate_spec.js
@@ -23,13 +23,13 @@ describe('ToffoliGateNode', function() {
     testUtil.isLoaded(toffoliGateNode, 'toffoli-gate', done);
   });
 
-  xit('pass qubit through gate', function(done) {
+  it('pass qubit through gate', function(done) {
     flow.add('quantum-circuit', 'n0', [['n1'], ['n1'], ['n1']],
         {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '3'});
     flow.add('toffoli-gate', 'n1', [['n2'], ['n2'], ['n2']], {targetPosition: 'Upper'});
     flow.addOutput('n2');
 
-    let payloadObject = [
+    let payloadObjectList = [
       {structure: {qubits: 3, cbits: 3},
         register: undefined,
         qubit: 0},
@@ -41,7 +41,7 @@ describe('ToffoliGateNode', function() {
         qubit: 2},
     ];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/toffoli-gate_spec.js
+++ b/test/nodes/toffoli-gate_spec.js
@@ -63,7 +63,7 @@ describe('ToffoliGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -72,7 +72,7 @@ describe('ToffoliGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });
 

--- a/test/nodes/toffoli-gate_spec.js
+++ b/test/nodes/toffoli-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const toffoliGateNode = require('../../nodes/quantum/toffoli-gate/toffoli-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -55,5 +56,24 @@ describe('ToffoliGateNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('toffoli-gate', 'n1', [['n2'],['n2'],['n2']], {targetPosition: 'Middle'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('toffoli-gate', 'n1', [['n2'],['n2'],['n2']], {targetPosition: 'Middle'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });
 

--- a/test/nodes/unitary-gate_spec.js
+++ b/test/nodes/unitary-gate_spec.js
@@ -52,7 +52,7 @@ describe('UnitaryGateNode', function() {
 
     const givenInput = {payload: '', topic: ''};
     const expectedMessage = errors.NOT_QUANTUM_NODE;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 
   it('should fail on receiving non-qubit object', function(done) {
@@ -61,6 +61,6 @@ describe('UnitaryGateNode', function() {
 
     const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
-    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+    testUtil.nodeFailed(flow, givenInput, expectedMessage, done);
   });
 });

--- a/test/nodes/unitary-gate_spec.js
+++ b/test/nodes/unitary-gate_spec.js
@@ -4,6 +4,7 @@ const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const unitaryGateNode = require('../../nodes/quantum/unitary-gate/unitary-gate.js');
 const snippets = require('../../nodes/snippets.js');
+const errors = require('../../nodes/errors');
 
 const flow = new FlowBuilder();
 
@@ -44,4 +45,23 @@ describe('UnitaryGateNode', function() {
 
     testUtil.commandExecuted(flow, command, done);
   });
+
+  it('should fail on receiving input from non-quantum nodes', function(done) {
+    flow.add('unitary-gate', 'n1', [['n2']], {theta: '0', phi: '0', lambda: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: '', topic: ''};
+    const expectedMessage = errors.NOT_QUANTUM_NODE;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
+  it('should fail on receiving non-qubit object', function(done) {
+    flow.add('unitary-gate', 'n1', [['n2']], {theta: '0', phi: '0', lambda: '0'});
+    flow.addOutput('n2');
+
+    const givenInput = {payload: {structure: '', qubit: 3}, topic: 'Quantum Circuit'};
+    const expectedMessage = errors.NOT_QUBIT_OBJECT;
+    testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
+  });
+
 });

--- a/test/nodes/unitary-gate_spec.js
+++ b/test/nodes/unitary-gate_spec.js
@@ -28,13 +28,13 @@ describe('UnitaryGateNode', function() {
     flow.add('unitary-gate', 'n1', [['n2']], {theta: '1', phi: '1', lambda: '1'});
     flow.addOutput('n2');
 
-    let payloadObject = {
+    let payloadObjectList = [{
       structure: {qubits: 1, cbits: 1},
       register: undefined,
       qubit: 0,
-    };
+    }];
 
-    testUtil.qubitsPassedThroughGate(flow, payloadObject, done);
+    testUtil.qubitsPassedThroughGate(flow, payloadObjectList, done);
   });
 
   it('execute command', function(done) {

--- a/test/nodes/unitary-gate_spec.js
+++ b/test/nodes/unitary-gate_spec.js
@@ -63,5 +63,4 @@ describe('UnitaryGateNode', function() {
     const expectedMessage = errors.NOT_QUBIT_OBJECT;
     testUtil.nodeFailed(flow, 'n1', givenInput, expectedMessage, done);
   });
-
 });

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -78,16 +78,15 @@ function correctOutputReceived(flowBuilder, givenInput, expectedOutput, done) {
   });
 }
 
-function nodeFailed(flowBuilder, nodeId, givenInput, expectedMessage, done) {
+function nodeFailed(flowBuilder, givenInput, expectedMessage, done) {
   nodeTestHelper.load(flowBuilder.nodes, flowBuilder.flow, function() {
-    let inputNode = nodeTestHelper.getNode(flowBuilder.inputId);
-    let targetNode = nodeTestHelper.getNode(nodeId);
-    targetNode.on('call:error', (call)=> {
+    let node = nodeTestHelper.getNode(flowBuilder.inputId);
+    node.on('call:error', (call) => {
       const actualError = call.firstArg;
       assert.strictEqual(actualError.message, expectedMessage);
       done();
     });
-    inputNode.receive(givenInput);
+    node.receive(givenInput);
   });
 }
 

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -20,22 +20,25 @@ function isLoaded(node, nodeName, done) {
 }
 
 // Test that qubits sucessfully passed through the gate.
-function qubitsPassedThroughGate(generatedFlow, expectedPayload, done) {
+function qubitsPassedThroughGate(generatedFlow, expectedPayloadList, done) {
   nodeTestHelper.load(generatedFlow.nodes, generatedFlow.flow, function() {
-    let inputNode = nodeTestHelper.getNode(generatedFlow.inputId);
+    let circuitNode = nodeTestHelper.getNode(generatedFlow.inputId);
     let outputNode = nodeTestHelper.getNode(generatedFlow.outputId);
-
+    let actualPayloadList = [];
     outputNode.on('input', function(msg) {
       try {
-        msg.should.have.property('payload', expectedPayload);
-        done();
+        actualPayloadList.push(msg.payload);
+        if (actualPayloadList.length === circuitNode.qbitsreg) {
+          assert.sameDeepMembers(actualPayloadList, expectedPayloadList);
+          done();
+        }
       } catch (err) {
         done(err);
       } finally {
         shell.stop();
       }
     });
-    inputNode.receive({payload: ''});
+    circuitNode.receive({payload: ''});
   });
 }
 

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -46,9 +46,7 @@ function commandExecuted(flowBuilder, command, done) {
   nodeTestHelper.load(flowBuilder.nodes, flowBuilder.flow, function() {
     let inputNode = nodeTestHelper.getNode(flowBuilder.inputId);
     let outputNode = nodeTestHelper.getNode(flowBuilder.outputId);
-    let called = false;
-    outputNode.on('input', function() {
-      if (called) return;
+    outputNode.once('input', function() {
       try {
         assert.strictEqual(shell.lastCommand, command);
         done();
@@ -56,10 +54,8 @@ function commandExecuted(flowBuilder, command, done) {
         done(err);
       } finally {
         shell.stop();
-        called = true;
       }
     });
-
     inputNode.receive({payload: ''});
   });
 }

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -44,7 +44,6 @@ function commandExecuted(flowBuilder, command, done) {
     let inputNode = nodeTestHelper.getNode(flowBuilder.inputId);
     let outputNode = nodeTestHelper.getNode(flowBuilder.outputId);
     let called = false;
-
     outputNode.on('input', function() {
       if (called) return;
       try {
@@ -62,10 +61,10 @@ function commandExecuted(flowBuilder, command, done) {
   });
 }
 
-function correctOutputReceived(flow, givenInput, expectedOutput, done) {
-  nodeTestHelper.load(flow.nodes, flow.flow, function() {
-    const inputNode = nodeTestHelper.getNode(flow.inputId);
-    const outputNode = nodeTestHelper.getNode(flow.outputId);
+function correctOutputReceived(flowBuilder, givenInput, expectedOutput, done) {
+  nodeTestHelper.load(flowBuilder.nodes, flowBuilder.flow, function() {
+    const inputNode = nodeTestHelper.getNode(flowBuilder.inputId);
+    const outputNode = nodeTestHelper.getNode(flowBuilder.outputId);
     outputNode.on('input', function(msg) {
       try {
         assert.deepEqual(msg.payload, expectedOutput);
@@ -80,10 +79,24 @@ function correctOutputReceived(flow, givenInput, expectedOutput, done) {
   });
 }
 
+function nodeFailed(flowBuilder, nodeId, givenInput, expectedMessage, done) {
+  nodeTestHelper.load(flowBuilder.nodes, flowBuilder.flow, function() {
+    let inputNode = nodeTestHelper.getNode(flowBuilder.inputId);
+    let targetNode = nodeTestHelper.getNode(nodeId);
+    targetNode.on('call:error', (call)=> {
+      const actualError = call.firstArg;
+      assert.strictEqual(actualError.message, expectedMessage);
+      done();
+    });
+    inputNode.receive(givenInput);
+  });
+}
+
 module.exports = {
   nodeTestHelper,
   isLoaded,
   qubitsPassedThroughGate,
   commandExecuted,
   correctOutputReceived,
+  nodeFailed
 };

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -97,5 +97,5 @@ module.exports = {
   qubitsPassedThroughGate,
   commandExecuted,
   correctOutputReceived,
-  nodeFailed
+  nodeFailed,
 };

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -64,7 +64,7 @@ function correctOutputReceived(flowBuilder, givenInput, expectedOutput, done) {
   nodeTestHelper.load(flowBuilder.nodes, flowBuilder.flow, function() {
     const inputNode = nodeTestHelper.getNode(flowBuilder.inputId);
     const outputNode = nodeTestHelper.getNode(flowBuilder.outputId);
-    outputNode.on('input', function(msg) {
+    outputNode.once('input', function(msg) {
       try {
         assert.deepEqual(msg.payload, expectedOutput);
         done();


### PR DESCRIPTION
### Purpose
To check that nodes correctly validate incoming inputs. Minor fixes for some test cases.


### Changes
- Added tests that check that node fail on receiving input from non-quantum nodes and on receiving non-qubit or non-register objects (ec25e3f)
- Fixed *Pass qubit through gate* tests that were failing because assertion wasn't done on aggregate list of qubit payloads, but rather on the first one (909ad4f). The only node that still has this failing test is *Multi-controlled U gate*
- Fixed *Execute command* test for Quantum Register node failing because of uninitialized outputs variable (b14823f)
- Fixed flaky test in bloch sphere spec file (f017bf1)
- Added a test to script node to check for correct output, fixed commandExecute test util function to check for input once, since several inputs result in test error (11cf675)


### New Requirements
<!-- List any new requirements that have been introduced to the project (e.g. new Node dependencies). Remove section if not relevant. -->
