### PR TITLE
Louis/ci-fixes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [12.x, 14.x, 16.x]
         python-version: [3.9]
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,10 @@
 name: Node.js CI
 
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         node-version: [12.x, 14.x, 16.x]
         python-version: [3.9]
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,10 +1,6 @@
 name: Node.js CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: push
 
 jobs:
   build:

--- a/nodes/logger.js
+++ b/nodes/logger.js
@@ -15,7 +15,7 @@ function formatDate(date) {
 }
 
 function logToFile(fileName, logLevel, id, message) {
-  if (process.env.NODE_ENV !== 'dev') {
+  if (!process.env.NODE_ENV || process.env.NODE_ENV.trim() !== 'dev') {
     return;
   }
 

--- a/nodes/quantum-algorithms/grovers/grovers.js
+++ b/nodes/quantum-algorithms/grovers/grovers.js
@@ -32,7 +32,7 @@ module.exports = function(RED) {
           .then((data) => {
             data = data.split('\n');
             msg.payload = {
-              topMeasurement: data[0],
+              topMeasurement: data[0].trim(),
               iterationsNum: Number(data[1]),
             };
             send(msg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "node-red-contrib-quantum",
       "version": "0.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -46,20 +45,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.4.tgz",
+      "integrity": "sha512-Lkcv9I4a8bgUI8LJOLM6IKv6hnz1KOju6KM1lceqVMKlKKqNRopYd2Pc9MgIurqvMJ6BooemrnJz8jlIiQIpsA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -97,12 +96,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -111,9 +110,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.15.0",
@@ -138,132 +137,132 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
         "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -288,14 +287,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -387,9 +386,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.4.tgz",
+      "integrity": "sha512-xmzz+7fRpjrvDUj+GV7zfz/R3gSK2cOxGlazaXooxspCr539cbTXJKvBJzSVI2pPhcRGquoOtaIkKCsHQUiO3w==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -399,9 +398,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -411,14 +410,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -437,18 +436,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -478,9 +477,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+      "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -622,13 +621,13 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@node-red/editor-api": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-1.3.6.tgz",
-      "integrity": "sha512-eAbqtcRxcplfXHkhaZJldY5aNmeOPxlMAyozIGu8telxpm34EtLkLC0g3zaEqihyIEOZ1bqpJsAdcS7Tz9ND4A==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-1.3.7.tgz",
+      "integrity": "sha512-tm+umybD+Bq/Kkj77/l9hOE60hfmfUCIzHwKaiDnSDJymHKuPy0eCNCg37MR/J9HodXtY5Th2we++4mUCS5uYA==",
       "dev": true,
       "dependencies": {
-        "@node-red/editor-client": "1.3.6",
-        "@node-red/util": "1.3.6",
+        "@node-red/editor-client": "1.3.7",
+        "@node-red/util": "1.3.7",
         "bcryptjs": "2.4.3",
         "body-parser": "1.19.0",
         "clone": "2.1.2",
@@ -650,15 +649,15 @@
       }
     },
     "node_modules/@node-red/editor-client": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-1.3.6.tgz",
-      "integrity": "sha512-FklaHsHuBwCgRsD0GoyqMZz1YkXWN9qSj8PSSThPviaLnK6y59KVzmUFAHDzHxenU4F306YyRyJ3Ifrtv0z6uQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-1.3.7.tgz",
+      "integrity": "sha512-ti1AwZOZq4a8Ro1QyiLnotfaIIJ8oHdzacH5f75bhNi9bv9UNVd5UikvKcjYSZAEFHUlEZ7IYk9Pg7DaGQiDbw==",
       "dev": true
     },
     "node_modules/@node-red/nodes": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-1.3.6.tgz",
-      "integrity": "sha512-MqhR34aFI5FpNnEfTjeX7w0zT6KlD9+DyJ2RnDSnAzXWTanUelpnkHR0tH98VPK2etjGUZjQejSwbEjjRWgN1w==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-1.3.7.tgz",
+      "integrity": "sha512-iQG6GeX+tHB92rSK3T+7KQAssDhSXNmV9tpp+8Zybyo1ljShWZ/A3ZI+z4qTbn1MJB123E5eDTZn86N/bQ29Gw==",
       "dev": true,
       "dependencies": {
         "acorn": "8.3.0",
@@ -716,16 +715,16 @@
       }
     },
     "node_modules/@node-red/registry": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-1.3.6.tgz",
-      "integrity": "sha512-d3CArCvr248yAXg7xn7Q2+MPfNPttDPdxD5psPalCeo4uDIodqZX7tFZ8DJGnUle7+fj6hCVSRQCNzjb/5rSkw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-1.3.7.tgz",
+      "integrity": "sha512-nv0GNzldsl+zSbKGNEueh8IIA4p6cr8AwBZd691mZGWv/7uPDwa2C/FPllagCMTs7+wtb7Q5gYDFz+1uGGlKyw==",
       "dev": true,
       "dependencies": {
-        "@node-red/util": "1.3.6",
+        "@node-red/util": "1.3.7",
         "clone": "2.1.2",
         "fs-extra": "8.1.0",
         "semver": "6.3.0",
-        "tar": "6.1.2",
+        "tar": "6.1.11",
         "uglify-js": "3.13.3"
       }
     },
@@ -739,13 +738,13 @@
       }
     },
     "node_modules/@node-red/runtime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-1.3.6.tgz",
-      "integrity": "sha512-JJY1re6nQCuIRgjPMlnsw+TDs/F6xtyJL6EcwUdoz5JfCXqEbUf8iCm7RuDph76/PF8DHL10HGQS0kmC54dZrw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-1.3.7.tgz",
+      "integrity": "sha512-4m6FnFy2qo9rQKet0MmUfLHC6gdhszfp5snoLzfAH8DZkBOdnqtnOHab7K4v4GyaXNS8pRoD6yD7ARiiYxGbug==",
       "dev": true,
       "dependencies": {
-        "@node-red/registry": "1.3.6",
-        "@node-red/util": "1.3.6",
+        "@node-red/registry": "1.3.7",
+        "@node-red/util": "1.3.7",
         "async-mutex": "0.3.1",
         "clone": "2.1.2",
         "express": "4.17.1",
@@ -754,9 +753,9 @@
       }
     },
     "node_modules/@node-red/util": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-1.3.6.tgz",
-      "integrity": "sha512-CLbnzArRprfr7DC0LEN4P1wXAdIZEQnSswn7jzYgfrXQkLYA45sjxrjzvPYT0NY0VnkA0s+qzMRyFkwWrjFxuA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-1.3.7.tgz",
+      "integrity": "sha512-k7uZgz6FaMqYZ3ixoGiII/gxoxJTlB0knKq59O7an4x9sORv17JjqIerF0Ok6UiOWYHdtH8cybzVsVPSxF7BGA==",
       "dev": true,
       "dependencies": {
         "fs-extra": "8.1.0",
@@ -1040,9 +1039,9 @@
       "dev": true
     },
     "node_modules/are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -1921,9 +1920,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.4.tgz",
-      "integrity": "sha512-Tq4GVE6XCjE+hcyW6hPy0ofN3hwtLudz5ZRdrlCnsnD/xkm/PWQRudzYHiKgZKUcefV6Q57fhDHjZHJP5dpfSg==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.2.tgz",
+      "integrity": "sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -2336,9 +2335,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.825",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.825.tgz",
-      "integrity": "sha512-BO3FfWVeH8GQ0DBbi4HCL09OPgvN+0goqWlgKOCmCXcnrlgL5GA69nb7ZyjpWgpFUacBftg8BrXU2WLOSuHAxQ==",
+      "version": "1.3.828",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.828.tgz",
+      "integrity": "sha512-2kx537tLqIVfUpx7LRknZce5PcCyxyBB1YUVOhxlkrDoCqFITGJGYfBAvSxGOdqlp+R9pHeU9Ai/dsHgsqjrvQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2919,9 +2918,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
-      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
       "dev": true,
       "funding": [
         {
@@ -4770,9 +4769,9 @@
       "dev": true
     },
     "node_modules/needle": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.0.tgz",
-      "integrity": "sha512-UBLC4P8w9to3rAhWOQYXIXzTUio9yVnDzIeKxfGbF+Hngy+2bXTqqFK+6nF42EAQKfJdezXK6vzMsefUa1Y3ag==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -5005,15 +5004,15 @@
       }
     },
     "node_modules/node-red": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/node-red/-/node-red-1.3.6.tgz",
-      "integrity": "sha512-pe4lxx76x2T/BEpvFN7qbzG6N586WpQHtDNfh40L0OGFTK2J48sydC3K1MkjNEa5bNepdMKPqygsY6HRdPeVMA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/node-red/-/node-red-1.3.7.tgz",
+      "integrity": "sha512-cdlRdl2ek10lVpGXXkxy4HPp8SoTw6s209bo9l7RN8jLMCwIU66FFBADHRhriWmxM9v6Mms1WJ4k0gETiiTfUA==",
       "dev": true,
       "dependencies": {
-        "@node-red/editor-api": "1.3.6",
-        "@node-red/nodes": "1.3.6",
-        "@node-red/runtime": "1.3.6",
-        "@node-red/util": "1.3.6",
+        "@node-red/editor-api": "1.3.7",
+        "@node-red/nodes": "1.3.7",
+        "@node-red/runtime": "1.3.7",
+        "@node-red/util": "1.3.7",
         "basic-auth": "2.0.1",
         "bcryptjs": "2.4.3",
         "express": "4.17.1",
@@ -7498,9 +7497,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
-      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -8197,20 +8196,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.4.tgz",
+      "integrity": "sha512-Lkcv9I4a8bgUI8LJOLM6IKv6hnz1KOju6KM1lceqVMKlKKqNRopYd2Pc9MgIurqvMJ6BooemrnJz8jlIiQIpsA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -8237,20 +8236,20 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.15.0",
@@ -8268,105 +8267,105 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
         "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -8382,14 +8381,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/highlight": {
@@ -8462,29 +8461,29 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.4.tgz",
+      "integrity": "sha512-xmzz+7fRpjrvDUj+GV7zfz/R3gSK2cOxGlazaXooxspCr539cbTXJKvBJzSVI2pPhcRGquoOtaIkKCsHQUiO3w==",
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -8499,18 +8498,18 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -8533,9 +8532,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+      "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -8646,13 +8645,13 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@node-red/editor-api": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-1.3.6.tgz",
-      "integrity": "sha512-eAbqtcRxcplfXHkhaZJldY5aNmeOPxlMAyozIGu8telxpm34EtLkLC0g3zaEqihyIEOZ1bqpJsAdcS7Tz9ND4A==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-1.3.7.tgz",
+      "integrity": "sha512-tm+umybD+Bq/Kkj77/l9hOE60hfmfUCIzHwKaiDnSDJymHKuPy0eCNCg37MR/J9HodXtY5Th2we++4mUCS5uYA==",
       "dev": true,
       "requires": {
-        "@node-red/editor-client": "1.3.6",
-        "@node-red/util": "1.3.6",
+        "@node-red/editor-client": "1.3.7",
+        "@node-red/util": "1.3.7",
         "bcrypt": "3.0.6",
         "bcryptjs": "2.4.3",
         "body-parser": "1.19.0",
@@ -8672,15 +8671,15 @@
       }
     },
     "@node-red/editor-client": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-1.3.6.tgz",
-      "integrity": "sha512-FklaHsHuBwCgRsD0GoyqMZz1YkXWN9qSj8PSSThPviaLnK6y59KVzmUFAHDzHxenU4F306YyRyJ3Ifrtv0z6uQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-1.3.7.tgz",
+      "integrity": "sha512-ti1AwZOZq4a8Ro1QyiLnotfaIIJ8oHdzacH5f75bhNi9bv9UNVd5UikvKcjYSZAEFHUlEZ7IYk9Pg7DaGQiDbw==",
       "dev": true
     },
     "@node-red/nodes": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-1.3.6.tgz",
-      "integrity": "sha512-MqhR34aFI5FpNnEfTjeX7w0zT6KlD9+DyJ2RnDSnAzXWTanUelpnkHR0tH98VPK2etjGUZjQejSwbEjjRWgN1w==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-1.3.7.tgz",
+      "integrity": "sha512-iQG6GeX+tHB92rSK3T+7KQAssDhSXNmV9tpp+8Zybyo1ljShWZ/A3ZI+z4qTbn1MJB123E5eDTZn86N/bQ29Gw==",
       "dev": true,
       "requires": {
         "acorn": "8.3.0",
@@ -8731,16 +8730,16 @@
       }
     },
     "@node-red/registry": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-1.3.6.tgz",
-      "integrity": "sha512-d3CArCvr248yAXg7xn7Q2+MPfNPttDPdxD5psPalCeo4uDIodqZX7tFZ8DJGnUle7+fj6hCVSRQCNzjb/5rSkw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-1.3.7.tgz",
+      "integrity": "sha512-nv0GNzldsl+zSbKGNEueh8IIA4p6cr8AwBZd691mZGWv/7uPDwa2C/FPllagCMTs7+wtb7Q5gYDFz+1uGGlKyw==",
       "dev": true,
       "requires": {
-        "@node-red/util": "1.3.6",
+        "@node-red/util": "1.3.7",
         "clone": "2.1.2",
         "fs-extra": "8.1.0",
         "semver": "6.3.0",
-        "tar": "6.1.2",
+        "tar": "6.1.11",
         "uglify-js": "3.13.3"
       },
       "dependencies": {
@@ -8753,13 +8752,13 @@
       }
     },
     "@node-red/runtime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-1.3.6.tgz",
-      "integrity": "sha512-JJY1re6nQCuIRgjPMlnsw+TDs/F6xtyJL6EcwUdoz5JfCXqEbUf8iCm7RuDph76/PF8DHL10HGQS0kmC54dZrw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-1.3.7.tgz",
+      "integrity": "sha512-4m6FnFy2qo9rQKet0MmUfLHC6gdhszfp5snoLzfAH8DZkBOdnqtnOHab7K4v4GyaXNS8pRoD6yD7ARiiYxGbug==",
       "dev": true,
       "requires": {
-        "@node-red/registry": "1.3.6",
-        "@node-red/util": "1.3.6",
+        "@node-red/registry": "1.3.7",
+        "@node-red/util": "1.3.7",
         "async-mutex": "0.3.1",
         "clone": "2.1.2",
         "express": "4.17.1",
@@ -8768,9 +8767,9 @@
       }
     },
     "@node-red/util": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-1.3.6.tgz",
-      "integrity": "sha512-CLbnzArRprfr7DC0LEN4P1wXAdIZEQnSswn7jzYgfrXQkLYA45sjxrjzvPYT0NY0VnkA0s+qzMRyFkwWrjFxuA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-1.3.7.tgz",
+      "integrity": "sha512-k7uZgz6FaMqYZ3ixoGiII/gxoxJTlB0knKq59O7an4x9sORv17JjqIerF0Ok6UiOWYHdtH8cybzVsVPSxF7BGA==",
       "dev": true,
       "requires": {
         "fs-extra": "8.1.0",
@@ -9003,9 +9002,9 @@
       "dev": true
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9727,9 +9726,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.4.tgz",
-      "integrity": "sha512-Tq4GVE6XCjE+hcyW6hPy0ofN3hwtLudz5ZRdrlCnsnD/xkm/PWQRudzYHiKgZKUcefV6Q57fhDHjZHJP5dpfSg=="
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.2.tgz",
+      "integrity": "sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -10066,9 +10065,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.825",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.825.tgz",
-      "integrity": "sha512-BO3FfWVeH8GQ0DBbi4HCL09OPgvN+0goqWlgKOCmCXcnrlgL5GA69nb7ZyjpWgpFUacBftg8BrXU2WLOSuHAxQ==",
+      "version": "1.3.828",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.828.tgz",
+      "integrity": "sha512-2kx537tLqIVfUpx7LRknZce5PcCyxyBB1YUVOhxlkrDoCqFITGJGYfBAvSxGOdqlp+R9pHeU9Ai/dsHgsqjrvQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -10540,9 +10539,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
-      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
       "dev": true
     },
     "foreground-child": {
@@ -11986,9 +11985,9 @@
       "dev": true
     },
     "needle": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.0.tgz",
-      "integrity": "sha512-UBLC4P8w9to3rAhWOQYXIXzTUio9yVnDzIeKxfGbF+Hngy+2bXTqqFK+6nF42EAQKfJdezXK6vzMsefUa1Y3ag==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -12182,15 +12181,15 @@
       }
     },
     "node-red": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/node-red/-/node-red-1.3.6.tgz",
-      "integrity": "sha512-pe4lxx76x2T/BEpvFN7qbzG6N586WpQHtDNfh40L0OGFTK2J48sydC3K1MkjNEa5bNepdMKPqygsY6HRdPeVMA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/node-red/-/node-red-1.3.7.tgz",
+      "integrity": "sha512-cdlRdl2ek10lVpGXXkxy4HPp8SoTw6s209bo9l7RN8jLMCwIU66FFBADHRhriWmxM9v6Mms1WJ4k0gETiiTfUA==",
       "dev": true,
       "requires": {
-        "@node-red/editor-api": "1.3.6",
-        "@node-red/nodes": "1.3.6",
-        "@node-red/runtime": "1.3.6",
-        "@node-red/util": "1.3.6",
+        "@node-red/editor-api": "1.3.7",
+        "@node-red/nodes": "1.3.7",
+        "@node-red/runtime": "1.3.7",
+        "@node-red/util": "1.3.7",
         "basic-auth": "2.0.1",
         "bcrypt": "3.0.6",
         "bcryptjs": "2.4.3",
@@ -14174,9 +14173,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
-      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "start": "export NODE_ENV=dev && (node-red || npx node-red)",
+    "start": "(export NODE_ENV=dev || set NODE_ENV=dev) && node-red || npx node-red",
+    "test": "(export NODE_ENV=dev || set NODE_ENV=dev) && mocha \"test/**/*_spec.js\" --timeout 10000",
     "setup": "npm install --silent && npm run link",
-    "test": "export NODE_ENV=dev && mocha \"test/**/*_spec.js\" --timeout 10000",
     "coverage": "nyc --reporter=lcovonly --reporter=text npm test",
     "venv": "bash bin/pyvenv.sh",
     "psvenv": "powershell -NoProfile -ExecutionPolicy Bypass -File ./bin/pyvenv.ps1",

--- a/test/nodes/bloch-sphere_spec.js
+++ b/test/nodes/bloch-sphere_spec.js
@@ -9,7 +9,7 @@ const flow = new FlowBuilder();
 
 describe('BlochSphereNode', function() {
   before(function() {
-    if (process.platform !== 'linux') {
+    if (process.platform === 'win32') {
       // eslint-disable-next-line
       this.skip();
     }

--- a/test/nodes/bloch-sphere_spec.js
+++ b/test/nodes/bloch-sphere_spec.js
@@ -8,6 +8,13 @@ const errors = require('../../nodes/errors');
 const flow = new FlowBuilder();
 
 describe('BlochSphereNode', function() {
+  before(function() {
+    if (process.platform !== 'linux') {
+      // eslint-disable-next-line
+      this.skip();
+    }
+  });
+
   beforeEach(function(done) {
     nodeTestHelper.startServer(done);
   });

--- a/test/nodes/circuit-diagram_spec.js
+++ b/test/nodes/circuit-diagram_spec.js
@@ -9,7 +9,7 @@ const flow = new FlowBuilder();
 
 describe('CircuitDiagramNode', function() {
   before(function() {
-    if (process.platform !== 'linux') {
+    if (process.platform === 'win32') {
       // eslint-disable-next-line
       this.skip();
     }

--- a/test/nodes/circuit-diagram_spec.js
+++ b/test/nodes/circuit-diagram_spec.js
@@ -8,6 +8,13 @@ const errors = require('../../nodes/errors');
 const flow = new FlowBuilder();
 
 describe('CircuitDiagramNode', function() {
+  before(function() {
+    if (process.platform !== 'linux') {
+      // eslint-disable-next-line
+      this.skip();
+    }
+  });
+
   beforeEach(function(done) {
     nodeTestHelper.startServer(done);
   });

--- a/test/python_spec.js
+++ b/test/python_spec.js
@@ -2,6 +2,24 @@ const shell = require('../nodes/python').PythonShell;
 const assert = require('chai').assert;
 const dedent = require('dedent-js');
 
+const convertNewline = `
+import sys
+sys.stdout = open(sys.__stdout__.fileno(),
+                  mode=sys.__stdout__.mode,
+                  buffering=1,
+                  encoding=sys.__stdout__.encoding,
+                  errors=sys.__stdout__.errors,
+                  newline='\\n',
+                  closefd=False)
+sys.stderr = open(sys.__stderr__.fileno(),
+                  mode=sys.__stderr__.mode,
+                  buffering=1,
+                  encoding=sys.__stderr__.encoding,
+                  errors=sys.__stderr__.errors,
+                  newline='\\n',
+                  closefd=False)
+`;
+
 const NAME_ERROR =
 `Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
@@ -15,7 +33,7 @@ describe('PythonShell', function() {
     });
 
     it('python path is default', async function() {
-      assert.match(shell.pythonPath, /(venv\/bin\/python)|(venv\/Scripts\/python.exe)/);
+      assert.match(shell.pythonPath, /(venv\/bin\/python)|(venv\\Scripts\\python.exe)/);
     });
 
     it('process starts empty', async function() {
@@ -81,6 +99,9 @@ describe('PythonShell', function() {
   describe('#execute', function() {
     beforeEach(async () => {
       shell.start();
+      if (process.platform === 'win32') {
+        await shell.execute(convertNewline);
+      }
     });
     afterEach(() => {
       shell.stop();


### PR DESCRIPTION
### Purpose
Activated Windows on the CI pipeline, and added fixes for getting unit tests to work on the CI pipeline for Windows. There is a really odd bug to do with the Bloch sphere and circuit diagram (and possibly matplotlib) which I'll explain in a new issue later on, so those tests are automatically disabled whenever run on a Windows machine.

### Changes
- Disable Bloch sphere and circuit diagram tests when running on Windows (0c93eef624a5adbb085f1503de5e998a9ff95a18).
- Fixed Python tests failing on Windows due to incorrect newline characters (ee91b3eb28f18a94c052bf5cff858024d0a0476f).
- Fix logging not triggering on Windows (0b685c4d0423692da223c43477c537339ad00ac6).
- Fix `NODE_ENV` export not working on Windows (166856bc718f6915a029597869149b227521fc91).
- Fix Grovers returning a trailing newline, causing test to fail on Windows (52f98a329bd74f5c1e0eec81dddc1f0d00e39d5d).
- Update project dependencies to latest versions (17f7cc89cb85187ac4d3dff358d2c78054ee8394).
- Add Windows to CI (658397701e6c6c0e1bd6f47b84968ae53f452185).

### New Requirements
- Run `npm install` to get the latest versions of dependencies.
